### PR TITLE
Right-click a tab to move Tree Style Tab sidebar

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -11,6 +11,9 @@
     "options_openAsChildOfCurrentTab": {
         "message": "When the sidebar page is opened in a seperate tab in the current window then that tab should be a child of the current tab. (The new tab must be placed after the current tab.)"
     },
+    "options_tab_ContextMenu": {
+        "message": "When a tab is right-clicked, show a context menu option to open the sidebar page in a new tab or window."
+    },
     "options_delayBeforeWindowSeperation": {
         "message": "When the sidebar page is loaded it takes a little while before it has determined what window it should control. Wait this long before moving the sidebar page's tab to a new window: "
     },

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -3,13 +3,13 @@
         "message": "Fix some style issues that occur when the Tree Style Tab sidebar page is opened in a tab."
     },
     "options_browserAction_OpenInNewWindow": {
-        "message": "When the browser action is clicked open the sidebar page in a new window."
+        "message": "When the browser action is clicked, open the sidebar page in a new window."
     },
     "options_openAfterCurrentTab": {
-        "message": "When the sidebar page is opened in a seperate tab in the current window then that tab should be placed after the current tab."
+        "message": "When the sidebar page is opened in a seperate tab in the current window, it should be placed after the current tab."
     },
     "options_openAsChildOfCurrentTab": {
-        "message": "When the sidebar page is opened in a seperate tab in the current window then that tab should be a child of the current tab. (The new tab must be placed after the current tab.)"
+        "message": "When the sidebar page is opened in a seperate tab in the current window, it should be a child of the current tab. (The new tab must be placed after the current tab.)"
     },
     "options_tab_ContextMenu": {
         "message": "When a tab is right-clicked, show a context menu option to open the sidebar page in a new tab or window."

--- a/background.js
+++ b/background.js
@@ -21,6 +21,12 @@ async function updateContextMenu() {
       let details = {
         contexts: ['browser_action']
       };
+      if (settings.tab_ContextMenu) {
+        details = {
+          contexts: ['browser_action', 'tab']
+        };
+      }
+      
       if (contextMenuId.startsWith('-')) {
         Object.assign(details, {
           type: 'separator',
@@ -270,6 +276,9 @@ settingsLoaded.finally(async () => {
         clearTimeout(id);
       }
       windowMoveTimeoutIds = [];
+    }
+    if (changes.tab_ContextMenu) {
+      updateContextMenu();
     }
   };
 

--- a/common.js
+++ b/common.js
@@ -162,6 +162,7 @@ function getDefaultSettings() {
 
     openAfterCurrentTab: true,
     openAsChildOfCurrentTab: false,
+    tab_ContextMenu: false,
     delayBeforeWindowSeperationInMilliseconds: 500,
   };
 }
@@ -210,3 +211,4 @@ let settingsLoaded = browser.storage.local.get(null).then((value) => {
 });
 
 // #endregion Settings
+

--- a/options/options.html
+++ b/options/options.html
@@ -32,6 +32,12 @@
         </label>
         <br />
         <br />
+        <label>
+            <input id="tab_ContextMenu" type="checkbox">
+            <text class="message_options_tab_ContextMenu"></text>
+        </label>
+        <br />
+        <br />
         <p>
           <span class="message_options_delayBeforeWindowSeperation"></span>
           <input id="delayBeforeWindowSeperationInMilliseconds" type="number" min="-1">


### PR DESCRIPTION
Add additional option to right-click a tab to move Tree Style Tab to a new tab or window.
Apologies for the mess.